### PR TITLE
Fix README - Middleware File Matcher parameter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ the given regular expression.
 
 ```ruby
 matcher = %r{^#{Regexp.escape(Rails.root.to_s)}/(app|config|lib|vendor/plugin)}
-use Pilfer::Middleware, :profiler       => profiler,
-                        :files_matching => matcher
+use Pilfer::Middleware, :profiler     => profiler,
+                        :file_matcher => matcher
 ```
 
 You almost certainly don't want to profile _every_ request. Provide a block to


### PR DESCRIPTION
According to the https://github.com/eric/pilfer/blob/master/lib/pilfer/middleware.rb#L11 middleware parameter should be named `:file_matcher`.

P.S.
Offtopic - BTW, I tested Pilfer on 2.0.0 and it works like a charm.
