### PR TITLE
Update README.md - env.query_string method

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The Rack environment is available to allow profiling on demand.
 ```ruby
 # Profile requests containing the query string ?profile=true
 use Pilfer::Middleware, :profiler => profiler do |env|
-  env.query_string.include? 'profile=true'
+  env["QUERY_STRING"].include? 'profile=true'
 end
 
 # Profile requests containing a header whose value matches a secret


### PR DESCRIPTION
Unfortunately `env.query_string` method is not accessible for Ruby 1.9.3:
`NoMethodError (undefined method `query_string' for #<Hash:0x007f89002a12b0>):`
